### PR TITLE
feat: Implement Push-to-Talk functionality

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import logo from "/assets/openai-logomark.svg";
 import EventLog from "./EventLog";
 import SessionControls from "./SessionControls";
@@ -8,12 +8,164 @@ export default function App() {
   const [isSessionActive, setIsSessionActive] = useState(false);
   const [events, setEvents] = useState([]);
   const [dataChannel, setDataChannel] = useState(null);
+  const [isPushToTalkEnabled, setIsPushToTalkEnabled] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
   const peerConnection = useRef(null);
   const audioElement = useRef(null);
+  const localStream = useRef(null);
+  const spaceKeyTimer = useRef(null);
+  const isRecordingRef = useRef(false); // 状態をrefでも管理
   const defaultModel = import.meta.env.VITE_OPENAI_MODEL || "gpt-4o-realtime-preview-2024-12-17";
   const [selectedModel, setSelectedModel] = useState(defaultModel);
 
+  // 録音開始
+  const startRecording = useCallback(() => {
+    if (!isSessionActive || !dataChannel || isRecordingRef.current) {
+      console.log("❌ Cannot start recording:", { isSessionActive, hasDataChannel: !!dataChannel, isRecording: isRecordingRef.current });
+      return;
+    }
+    
+    console.log("📢 startRecording called");
+    isRecordingRef.current = true;
+    setIsRecording(true);
+    
+    // マイクを有効にする
+    toggleMicrophone(true);
+    
+    // 5秒後に自動的に停止するタイマーを設定（安全装置）
+    if (spaceKeyTimer.current) {
+      clearTimeout(spaceKeyTimer.current);
+    }
+    spaceKeyTimer.current = setTimeout(() => {
+      console.log("⏰ Timer: Auto-stopping recording after 5 seconds");
+      stopRecording();
+    }, 5000);
+    
+    console.log("✅ Recording started");
+  }, [isSessionActive, dataChannel]);
+
+  // 録音停止
+  const stopRecording = useCallback(() => {
+    if (!isRecordingRef.current) {
+      console.log("⚠️ stopRecording called but not recording");
+      return;
+    }
+    
+    console.log("📢 stopRecording called");
+    
+    // タイマーをクリア
+    if (spaceKeyTimer.current) {
+      clearTimeout(spaceKeyTimer.current);
+      spaceKeyTimer.current = null;
+    }
+    
+    isRecordingRef.current = false;
+    setIsRecording(false);
+    
+    // マイクを無効にする
+    toggleMicrophone(false);
+    
+    // OpenAI Realtime APIにレスポンス生成を要求
+    sendClientEvent({
+      type: "response.create"
+    });
+    
+    console.log("🛑 Recording stopped");
+  }, []);
+
+  // キーボードイベントの処理
+  useEffect(() => {
+    if (!isPushToTalkEnabled || !isSessionActive) {
+      console.log("🚫 Keyboard events disabled", { isPushToTalkEnabled, isSessionActive });
+      return;
+    }
+
+    console.log("🎯 Setting up keyboard events");
+
+    const handleKeyDown = (event) => {
+      console.log("⌨️ Key down:", event.code, "Repeat:", event.repeat, "Recording:", isRecordingRef.current);
+      
+      if (event.code === 'Space' && !event.repeat && !isRecordingRef.current) {
+        event.preventDefault();
+        console.log("🔴 Space DOWN - calling startRecording");
+        startRecording();
+      }
+    };
+
+    const handleKeyUp = (event) => {
+      console.log("⌨️ Key up:", event.code, "Recording:", isRecordingRef.current);
+      
+      if (event.code === 'Space' && isRecordingRef.current) {
+        event.preventDefault();
+        console.log("🔵 Space UP - calling stopRecording");
+        stopRecording();
+      }
+    };
+
+    // windowとdocumentの両方にイベントリスナーを追加
+    window.addEventListener('keydown', handleKeyDown, true);
+    window.addEventListener('keyup', handleKeyUp, true);
+    document.addEventListener('keydown', handleKeyDown, true);
+    document.addEventListener('keyup', handleKeyUp, true);
+
+    return () => {
+      console.log("🧹 Cleaning up keyboard events");
+      window.removeEventListener('keydown', handleKeyDown, true);
+      window.removeEventListener('keyup', handleKeyUp, true);
+      document.removeEventListener('keydown', handleKeyDown, true);
+      document.removeEventListener('keyup', handleKeyUp, true);
+      
+      // タイマーもクリア
+      if (spaceKeyTimer.current) {
+        clearTimeout(spaceKeyTimer.current);
+        spaceKeyTimer.current = null;
+      }
+    };
+  }, [isPushToTalkEnabled, isSessionActive, startRecording, stopRecording]);
+
+  // マイクの有効/無効を切り替える
+  const toggleMicrophone = (enabled) => {
+    if (localStream.current) {
+      const audioTrack = localStream.current.getAudioTracks()[0];
+      if (audioTrack) {
+        audioTrack.enabled = enabled;
+        console.log(`🎤 Microphone ${enabled ? 'enabled' : 'disabled'}`);
+      } else {
+        console.log("❌ No audio track found");
+      }
+    } else {
+      console.log("❌ No local stream found");
+    }
+  };
+
+  // Push-to-Talkモードの切り替え
+  const togglePushToTalk = () => {
+    const newMode = !isPushToTalkEnabled;
+    setIsPushToTalkEnabled(newMode);
+    
+    console.log("🔄 Push-to-Talk mode:", newMode);
+    
+    // 録音状態をリセット
+    isRecordingRef.current = false;
+    setIsRecording(false);
+    
+    if (spaceKeyTimer.current) {
+      clearTimeout(spaceKeyTimer.current);
+      spaceKeyTimer.current = null;
+    }
+    
+    if (newMode) {
+      // Push-to-Talkモード: デフォルトでマイクを無効にする
+      toggleMicrophone(false);
+    } else {
+      // 常時録音モード: マイクを有効にする
+      toggleMicrophone(true);
+    }
+  };
+
   async function startSession() {
+    console.log("🚀 Starting session...");
+    
     // Get a session token for OpenAI Realtime API
     const tokenResponse = await fetch("/token");
     const data = await tokenResponse.json();
@@ -31,7 +183,19 @@ export default function App() {
     const ms = await navigator.mediaDevices.getUserMedia({
       audio: true,
     });
-    pc.addTrack(ms.getTracks()[0]);
+    
+    localStream.current = ms;
+    const audioTrack = ms.getTracks()[0];
+    
+    console.log("🎤 Audio track created:", audioTrack);
+    
+    // Push-to-Talkモードが有効な場合、最初はマイクを無効にする
+    if (isPushToTalkEnabled) {
+      audioTrack.enabled = false;
+      console.log("🔇 Initial microphone disabled (Push-to-Talk mode)");
+    }
+    
+    pc.addTrack(audioTrack);
 
     // Set up data channel for sending and receiving events
     const dc = pc.createDataChannel("oai-events");
@@ -42,8 +206,6 @@ export default function App() {
     await pc.setLocalDescription(offer);
 
     const baseUrl = "https://api.openai.com/v1/realtime";
-    //const model = "gpt-4o-realtime-preview-2024-12-17";
-    //const model = "gpt-4o-mini-transcribe";
     const sdpResponse = await fetch(`${baseUrl}?model=${selectedModel}`, {
       method: "POST",
       body: offer.sdp,
@@ -64,8 +226,25 @@ export default function App() {
 
   // Stop current session, clean up peer connection and data channel
   function stopSession() {
+    console.log("🛑 Stopping session...");
+    
+    // タイマーをクリア
+    if (spaceKeyTimer.current) {
+      clearTimeout(spaceKeyTimer.current);
+      spaceKeyTimer.current = null;
+    }
+    
+    // 録音状態をリセット
+    isRecordingRef.current = false;
+    setIsRecording(false);
+    
     if (dataChannel) {
       dataChannel.close();
+    }
+
+    if (localStream.current) {
+      localStream.current.getTracks().forEach(track => track.stop());
+      localStream.current = null;
     }
 
     peerConnection.current.getSenders().forEach((sender) => {
@@ -91,6 +270,7 @@ export default function App() {
 
       // send event before setting timestamp since the backend peer doesn't expect this field
       dataChannel.send(JSON.stringify(message));
+      console.log("📤 Sent event:", message.type);
 
       // if guard just in case the timestamp exists by miracle
       if (!message.timestamp) {
@@ -140,6 +320,7 @@ export default function App() {
 
       // Set session active when the data channel is opened
       dataChannel.addEventListener("open", () => {
+        console.log("🔗 Data channel opened");
         setIsSessionActive(true);
         setEvents([]);
       });
@@ -152,8 +333,31 @@ export default function App() {
         <div className="flex items-center gap-4 w-full m-4 pb-2 border-0 border-b border-solid border-gray-200">
           <img style={{ width: "24px" }} src={logo} />
           <h1>realtime console</h1>
+          
+          {/* Push-to-Talk制御パネル */}
+          <div className="ml-auto flex items-center gap-4">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={isPushToTalkEnabled}
+                onChange={togglePushToTalk}
+                disabled={isSessionActive}
+              />
+              <span className="text-sm">Push-to-Talk モード</span>
+            </label>
+            
+            {isPushToTalkEnabled && (
+              <div className="flex items-center gap-2">
+                <div className={`w-3 h-3 rounded-full ${isRecording ? 'bg-red-500' : 'bg-gray-300'}`}></div>
+                <span className="text-sm">
+                  {isRecording ? '録音中（5秒で自動停止）' : 'スペースキーを押して話す'}
+                </span>
+              </div>
+            )}
+          </div>
         </div>
       </nav>
+      
       <main className="absolute top-16 left-0 right-0 bottom-0">
         <section className="absolute top-0 left-0 right-[380px] bottom-0 flex">
           <section className="absolute top-0 left-0 right-0 bottom-32 px-4 overflow-y-auto">
@@ -167,6 +371,10 @@ export default function App() {
               sendTextMessage={sendTextMessage}
               events={events}
               isSessionActive={isSessionActive}
+              isPushToTalkEnabled={isPushToTalkEnabled}
+              isRecording={isRecording}
+              startRecording={startRecording}
+              stopRecording={stopRecording}
             />
           </section>
         </section>

--- a/client/components/SessionControls.jsx
+++ b/client/components/SessionControls.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { CloudLightning, CloudOff, MessageSquare } from "react-feather";
+import { CloudLightning, CloudOff, MessageSquare, Mic, MicOff } from "react-feather";
 import Button from "./Button";
 
 function SessionStopped({ startSession }) {
@@ -25,7 +25,14 @@ function SessionStopped({ startSession }) {
   );
 }
 
-function SessionActive({ stopSession, sendTextMessage }) {
+function SessionActive({ 
+  stopSession, 
+  sendTextMessage, 
+  isPushToTalkEnabled, 
+  isRecording, 
+  startRecording, 
+  stopRecording 
+}) {
   const [message, setMessage] = useState("");
 
   function handleSendClientEvent() {
@@ -47,6 +54,7 @@ function SessionActive({ stopSession, sendTextMessage }) {
         value={message}
         onChange={(e) => setMessage(e.target.value)}
       />
+      
       <Button
         onClick={() => {
           if (message.trim()) {
@@ -58,6 +66,18 @@ function SessionActive({ stopSession, sendTextMessage }) {
       >
         send text
       </Button>
+
+      {/* Push-to-Talk制御ボタン */}
+      {isPushToTalkEnabled && (
+        <Button
+          onClick={isRecording ? stopRecording : startRecording}
+          className={isRecording ? "bg-red-500" : "bg-green-500"}
+          icon={isRecording ? <MicOff height={16} /> : <Mic height={16} />}
+        >
+          {isRecording ? "停止" : "録音"}
+        </Button>
+      )}
+      
       <Button onClick={stopSession} icon={<CloudOff height={16} />}>
         disconnect
       </Button>
@@ -72,6 +92,10 @@ export default function SessionControls({
   sendTextMessage,
   serverEvents,
   isSessionActive,
+  isPushToTalkEnabled,
+  isRecording,
+  startRecording,
+  stopRecording,
 }) {
   return (
     <div className="flex gap-4 border-t-2 border-gray-200 h-full rounded-md">
@@ -81,6 +105,10 @@ export default function SessionControls({
           sendClientEvent={sendClientEvent}
           sendTextMessage={sendTextMessage}
           serverEvents={serverEvents}
+          isPushToTalkEnabled={isPushToTalkEnabled}
+          isRecording={isRecording}
+          startRecording={startRecording}
+          stopRecording={stopRecording}
         />
       ) : (
         <SessionStopped startSession={startSession} />


### PR DESCRIPTION
## 概要
展示場などの騒音環境で使用するためのPush-to-Talk機能を実装しました。

## 実装内容
- [ ] Push-to-Talkモードの切り替え機能
- [ ] スペースキー押下中のみ録音する機能
- [ ] 録音状態の視覚的インジケーター
- [ ] 5秒自動停止の安全装置
- [ ] 手動録音ボタン
- [ ] 録音していない時のマイク完全無効化

## テスト結果
- [x] Push-to-Talkモードのオン/オフ切り替え
- [x] スペースキーでの録音開始/停止
- [x] 視覚的フィードバック（赤丸表示）
- [x] 5秒タイマーによる自動停止
- [x] AIの応答生成

## 使用方法
1. セッション開始前に「Push-to-Talk モード」にチェック
2. セッション開始
3. スペースキーを押しながら話す
4. キーを離すとAIが応答

## 動作環境
- ブラウザ: Chrome/Edge/Firefox
- 要マイクアクセス許可